### PR TITLE
Update metadata to point to github issue tracker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,4 +24,17 @@ WriteMakefile(
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES    => 'HTML-Laundry-*' },
+    META_MERGE => {
+        'meta-spec' => { version => 2.0 },
+        resources => {
+            repository => {
+                type => 'git',
+                web => 'https://github.com/snark/html-laundry',
+                url => 'https://github.com/snark/html-laundry',
+            },
+            bugtracker => {
+                web => 'https://github.com/snark/html-laundry/issues',
+            },
+        },
+    },
 );


### PR DESCRIPTION
I got the impression from your docs that you wanted to use github issues instead of RT. This just updates the metadata so metacpan.org etc link to the correct issue tracker.

Thanks for the module
