### PR TITLE
UTF8 test fails - not compatible with the latest HTML::Tidy

### DIFF
--- a/t/tidy_default.t
+++ b/t/tidy_default.t
@@ -3,24 +3,34 @@ use warnings;
 
 use Test::More tests => 20;
 use Test::Exception;
+use Encode;
 
 require_ok('HTML::Laundry');
-my $tidy_available;
-eval {
-	require HTML::Tidy;
-	$tidy_available = 1;
+
+my $tidy_available = eval {
+   require HTML::Tidy;
+   1;
 };
 
 SKIP: {
-    skip 'HTML::Tidy unavailable; skipping tidy tests', 19 unless ( $tidy_available );
+    skip 'HTML::Tidy unavailable; skipping tidy tests', 19 unless $tidy_available;
     my $l = HTML::Laundry->new();
     is( $l->{tidy_engine}, q{HTML::Tidy}, 'HTML::Tidy is default tidying engine; sets tidy_engine key');
     my $plaintext = 'She was the youngest of the two daughters of a most affectionate, indulgent father...';
     is( $l->clean($plaintext), $plaintext, 'Short plain text passes through cleanly');
     $plaintext = q{She had been a friend and companion such as few possessed: intelligent, well-informed, useful, gentle, knowing all the ways of the family, interested in all its concerns, and peculiarly interested in herself, in every pleasure, every scheme of hers--one to whom she could speak every thought as it arose, and who had such an affection for her as could never find fault.};
     is( $l->clean($plaintext), $plaintext, 'Longer plain text passes through cleanly');
-    my $kurosawa = q[Akira Kurosawa (Kyūjitai: 黒澤 明, Shinjitai: 黒沢 明 Kurosawa Akira, 23 March 1910 – 6 September 1998) was a legendary Japanese filmmaker, producer, screenwriter and editor];
-    is( $l->clean($kurosawa), $kurosawa, 'UTF-8 text passes through cleanly');
+
+    TODO: {
+        # HTML::Tidy 1.56 fixes unicode support
+        local $TODO = "HTML::Tidy version dependent. Install HTML::Tidy 1.56 or greater"
+            unless eval { HTML::Tidy->VERSION(1.56) };
+
+        my $kurosawa_chars = Encode::encode('UTF-8', q[Akira Kurosawa (Kyūjitai: 黒澤 明, Shinjitai: 黒沢 明 Kurosawa Akira, 23 March 1910 – 6 September 1998) was a legendary Japanese filmmaker, producer, screenwriter and editor]);
+        my $kurosawa_bytes = Encode::decode('UTF-8', $kurosawa_chars);
+        is( $l->clean($kurosawa_chars), $kurosawa_bytes, 'UTF-8 text passes through cleanly');
+    };
+
     my $valid = q{<p>} . $plaintext . q{</p>};
     is( $l->clean($valid), $valid, 'Validating HTML passes through cleanly');
     TODO: {


### PR DESCRIPTION
```
t/tidy_default.t ...... 1/20
#   Failed test 'UTF-8 text passes through cleanly'
#   at t/tidy_default.t line 23.
Wide character in print at /data0/www/adcourier.broadbean/andy/lib/perl5/Test/Builder.pm line 1826.
#          got: 'Akira Kurosawa (Kyūjitai: 黒澤 明, Shinjitai: 黒沢 明 Kurosawa Akira, 23 March 1910 – 6 September 1998) was a legendary Japanese filmmaker, producer, screenwriter and editor'
#     expected: 'Akira Kurosawa (KyÅ«jitai: é»æ¾¤ æ, Shinjitai: é»æ²¢ æ Kurosawa Akira, 23 March 1910 â 6 September 1998) was a legendary Japanese filmmaker, producer, screenwriter and editor'
# Looks like you failed 1 test of 20
```

This fails because older versions of HTML::Tidy did not handle unicode correctly (https://github.com/petdance/html-tidy/issues/8)

HTML::Tidy 1.56 fixes that issue and now the test fails.

I have updated the test and skipped it under older versions of HTML::Tidy. I'd prefer to explicitly say require HTML::Tidy 1.56+ so people installing the module get a warning if they install this module with an older version of HTML::Tidy however I don't have the slightest idea how to do that for optional dependencies
